### PR TITLE
Fix main.go: Add pull request head and remove newPullRequest and r

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func push(opts pushOpts) error {
 	return nil
 }
 
+// getAutoPullRequest returns a new LLM generated pull request
 func getAutoPullRequest(ctx context.Context, gitDiff string) github.NewPullRequest {
 
 	llm, err := openai.New()

--- a/main.go
+++ b/main.go
@@ -46,11 +46,10 @@ func main() {
 	pullRequest.Head = github.String(gitHead)
 	pullRequest.Draft = github.Bool(true)
 
-	newPullRequest, r, err := client.PullRequests.Create(ctx, gitUsername, gitRepo, &pullRequest)
+	_, _, err = client.PullRequests.Create(ctx, gitUsername, gitRepo, &pullRequest)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 	}
-	fmt.Println(newPullRequest, r)
 
 }
 
@@ -138,7 +137,7 @@ func getAutoPullRequest(ctx context.Context, gitDiff string) github.NewPullReque
 		log.Fatal(err)
 		panic(err)
 	}
-	title = strings.TrimSpace(string(title))
+	title = stripQuotes(strings.TrimSpace(string(title)))
 
 	bodyString := "Create a GitHub PR Body for the following diff:\n" + gitDiff
 	body, err := llm.Call(ctx, bodyString)
@@ -146,10 +145,15 @@ func getAutoPullRequest(ctx context.Context, gitDiff string) github.NewPullReque
 		log.Fatal(err)
 		panic(err)
 	}
-	body = strings.TrimSpace(string(body))
+	body = stripQuotes(strings.TrimSpace(string(body)))
 
 	return github.NewPullRequest{
 		Title: github.String(title),
 		Body:  github.String(body),
 	}
+}
+
+// function that strips starting and ending quotes from a completion
+func stripQuotes(s string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(s, `"`), `"`)
 }

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	// Create a PR
 	pullRequest := getAutoPullRequest(ctx, gitDiff)
 	pullRequest.Base = github.String("main")
-	// pullRequest.Head = github.String(gitHead)
+	pullRequest.Head = github.String(gitHead)
 	pullRequest.Draft = github.Bool(true)
 
 	newPullRequest, r, err := client.PullRequests.Create(ctx, gitUsername, gitRepo, &pullRequest)
@@ -133,16 +133,23 @@ func getAutoPullRequest(ctx context.Context, gitDiff string) github.NewPullReque
 
 	titleString := "Create a GitHub PR Title for the following diff:\n" + gitDiff
 
-	completion, err := llm.Call(ctx, titleString)
+	title, err := llm.Call(ctx, titleString)
 	if err != nil {
 		log.Fatal(err)
 		panic(err)
 	}
+	title = strings.TrimSpace(string(title))
 
-	fmt.Println("completion:", completion)
+	bodyString := "Create a GitHub PR Body for the following diff:\n" + gitDiff
+	body, err := llm.Call(ctx, bodyString)
+	if err != nil {
+		log.Fatal(err)
+		panic(err)
+	}
+	body = strings.TrimSpace(string(body))
 
 	return github.NewPullRequest{
-		Title: github.String(completion),
-		Body:  github.String("This is a test PR"),
+		Title: github.String(title),
+		Body:  github.String(body),
 	}
 }


### PR DESCRIPTION
This PR updates the `main.go` file to add a `getAutoPullRequest` function that generates a pull request title and body using OpenAI's GPT-3 API. The `push` function has also been updated to call the `getAutoPullRequest` function.