### PR TITLE
Update go.mod and go.sum to golang.org/x/crypto v0.0.0-20210817164053-32db794688a5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fraser-isbester/ghgpt-go
+module github.com/fraser-isbester/github-gpt-go
 
 go 1.20
 
@@ -11,7 +11,7 @@ require (
 require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	golang.org/x/crypto v0.6.0 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,9 +14,8 @@ github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17
 github.com/tmc/langchaingo v0.0.0-20230515003257-704a9bb9e313 h1:+rZfAOJvziDkJlIL99rKQpQyGp5Y2yVTGxz7oQhLmYI=
 github.com/tmc/langchaingo v0.0.0-20230515003257-704a9bb9e313/go.mod h1:VQEc7xIJao42vl4zJtVWvJxaDHKhlkz8NwPjNqujKc8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
-golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=


### PR DESCRIPTION
This pull request updates the module name from `github.com/fraser-isbester/ghgpt-go` to `github.com/fraser-isbester/github-gpt-go` and updates the version of `golang.org/x/crypto` from `v0.6.0` to `v0.0.0-20210817164053-32db794688a5` in the `go.mod` and `go.sum` files.

> PR Created by [GitHub GPT](https://github.com/Fraser-Isbester/github-gpt-go) 🤗